### PR TITLE
Additional status file info + code cleanup

### DIFF
--- a/camp-collective/__main__.py
+++ b/camp-collective/__main__.py
@@ -52,8 +52,9 @@ async def do_login(bc):
         print(Fore.RED + "No user logged in with given cookies" + Fore.RESET)
         exit(1)
 
-    print(Fore.GREEN + 'Logged in as ' + Fore.BLUE + bc.user['name'] + Fore.GREEN + ' (' + Fore.CYAN + bc.user[
-        'username'] + Fore.GREEN + ')' + Fore.RESET)
+    print("{cg}Logged in as {cb}{bc.user[name]}{cg} ({cc}{bc.user[username]}{cg}){r}".format(
+        cy=Fore.YELLOW, cc=Fore.CYAN, cg=Fore.GREEN, cb=Fore.BLUE, r=Fore.RESET, bc=bc
+    ))
 
 
 def on_executor(func):
@@ -79,8 +80,8 @@ async def download_collection(bc, parallel, status_file=None, file_format=None):
     file_format = file_format.lower()
 
     if file_format not in Bandcamp.FORMATS:
-        print(Fore.RED + "Please use one of the following formats: " + Fore.CYAN + (Fore.RED + ', ' + Fore.CYAN).join(
-            Bandcamp.FORMATS) + Fore.RESET)
+        print(Fore.RED + "Please use one of the following formats: " + Fore.CYAN
+              + (Fore.RED + ', ' + Fore.CYAN).join(Bandcamp.FORMATS) + Fore.RESET)
         exit(1)
 
     await do_login(bc)
@@ -113,32 +114,28 @@ async def download_collection(bc, parallel, status_file=None, file_format=None):
         step = 0
         # But it looks sexy in the console!
         while len(queue) > 0 or working > 0:
-            message = ((ansi.clear_line() + ansi.Cursor.UP(
-                1)) * last_height) + ansi.clear_line() + '\r' + Fore.YELLOW + "Queued: " + Fore.GREEN + str(
-                len(queue)) + Fore.YELLOW + " Working: " + Fore.GREEN + str(
-                working) + Fore.YELLOW + " Done: " + Fore.GREEN + str(
-                done) + Fore.YELLOW + " Failed: " + Fore.RED + str(failed) + Fore.RESET + "\n\n"
+            message = (ansi.clear_line() + ansi.Cursor.UP(1)) * last_height
+            message += '{clear}\r{cy}Queued: {cg}{nq}{cy} Working: {cg}{nw}' \
+                       '{cy} Done: {cg}{nd}{cy} Failed: {cr}{nf}{r}\n\n'.format(
+                           clear=ansi.clear_line(), cy=Fore.YELLOW,
+                           cg=Fore.GREEN, cr=Fore.RED, r=Fore.RESET,
+                           nq=len(queue), nw=working, nd=done, nf=failed)
 
             for val in bc.download_status.values():
-                if val['status'] not in ['downloading', 'converting', 'requested']:
+                if val['status'] not in ('downloading', 'converting', 'requested'):
                     continue
 
-                message += Fore.YELLOW + '['
-                if val['status'] == 'converting' or val['status'] == 'requested':
+                message += Fore.YELLOW + '[' + Fore.BLUE
+                if val['status'] in ('converting', 'requested'):
                     bar = '.. .. ..'
-                    message += Fore.BLUE + bar[step:step + 4]
+                    message += bar[step:step + 4]
 
-                if val['status'] == 'downloading':
-                    percent = str(round(
-                        (val['downloaded_size'] / val['size']) * 100))
+                elif val['status'] == 'downloading':
+                    message += "{:>4.0%}".format(val['downloaded_size'] / val['size'])
 
-                    percent = (" " * (3 - len(percent))) + percent
-
-                    message += Fore.BLUE + percent + '%'
-
-                message += Fore.YELLOW + '] ' + Fore.CYAN + val[
-                    'item'].name + Fore.YELLOW + ' by ' + Fore.GREEN + val[
-                               'item'].artist + Fore.RESET + "\n"
+                message += "{cy}] {cc}{v[item].name}{cy} by {cg}{v[item].artist}{r}\n".format(
+                    cy=Fore.YELLOW, cc=Fore.CYAN, cg=Fore.GREEN, r=Fore.RESET, v=val
+                )
 
             last_height = message.count("\n")
             print(message, end="")
@@ -189,7 +186,9 @@ async def download_collection(bc, parallel, status_file=None, file_format=None):
     if failed > 0:
         print(Fore.YELLOW + '\nThe following items failed:')
         for item in failed_items:
-            print(Fore.CYAN + item.name + Fore.YELLOW + ' by ' + Fore.GREEN + item.artist + Fore.YELLOW + ': ' + Fore.BLUE + item.url + Fore.RESET)
+            print("{cc}{i.name}{cy} by {cg}{i.artist}{cy}: {cb}{i.url}{r}".format(
+                cy=Fore.YELLOW, cc=Fore.CYAN, cg=Fore.GREEN, cb=Fore.BLUE, r=Fore.RESET, i=item,
+            ))
 
     print(Fore.GREEN + 'Done!' + Fore.RESET)
 

--- a/camp-collective/__main__.py
+++ b/camp-collective/__main__.py
@@ -18,7 +18,7 @@ Options:
     --parallel=<amount> -p     Amount of items that should be downloaded parallel [default: 5]
     --status=<status-file> -s  Status file to save the status in of downloaded releases, so we don't over do it
     --format=<file-format> -f  File format to download (%s) [default: flac]
-""" % ', '.join(Bandcamp.FORMATS)
+""" % ', '.join(Bandcamp.FORMATS.keys())
 data = docopt(DOC)
 
 
@@ -79,9 +79,9 @@ def write_contents_to_file(filename, data):
 async def download_collection(bc, parallel, status_file=None, file_format=None):
     file_format = file_format.lower()
 
-    if file_format not in Bandcamp.FORMATS:
+    if file_format not in Bandcamp.FORMATS.keys():
         print(Fore.RED + "Please use one of the following formats: " + Fore.CYAN
-              + (Fore.RED + ', ' + Fore.CYAN).join(Bandcamp.FORMATS) + Fore.RESET)
+              + (Fore.RED + ', ' + Fore.CYAN).join(Bandcamp.FORMATS.keys()) + Fore.RESET)
         exit(1)
 
     await do_login(bc)

--- a/camp-collective/__main__.py
+++ b/camp-collective/__main__.py
@@ -25,8 +25,8 @@ data = docopt(DOC)
 async def _main(data):
     cookie_string = ';'.join(data['--cookie']).strip(' ;')
 
-    def parse_cookie(str):
-        kv = str.split('=', maxsplit=1)
+    def parse_cookie(string):
+        kv = string.split('=', maxsplit=1)
 
         if len(kv) == 1:
             kv.append(None)
@@ -91,7 +91,6 @@ async def download_collection(bc, parallel, status_file=None, file_format=None):
     done = 0
     failed = 0
     failed_items = []
-    status = {}
 
     if status_file is not None:
         if not isfile(status_file):
@@ -104,9 +103,11 @@ async def download_collection(bc, parallel, status_file=None, file_format=None):
 
         json_status = await read_file_in_memory(status_file)
         status = json.loads(json_status)
+    else:
+        status = {}
 
-    queue = [item for item in coll.items.values(
-    ) if item.id not in status or not status[item.id]]
+    queue = [item for item in coll.items.values()
+             if item.id not in status or not status[item.id]]
 
     async def print_progress():
         nonlocal working, done, failed

--- a/camp-collective/__main__.py
+++ b/camp-collective/__main__.py
@@ -161,7 +161,11 @@ async def download_collection(bc, parallel, status_file=None, file_format=None):
             failed += 1
             failed_items.append(item)
         else:
-            status[item.id] = True
+            item_dict = item.as_dict()
+            del item_dict['download_url']
+            item_dict['file'] = res
+            item_dict['quality'] = file_format
+            status[item.id] = item_dict
 
     async def queue_download():
         nonlocal working

--- a/camp-collective/bandcamp.py
+++ b/camp-collective/bandcamp.py
@@ -147,10 +147,12 @@ class Bandcamp:
 
         match = re.search(r"filename\*=UTF-8''(.+)",
                           resp.headers.get('content-disposition'))
-        file = self.download_directory + '/' + item.id + '.zip'
 
         if match:
-            file = self.download_directory + '/' + unquote(str(match.group(1)))
+            file = os.path.join(self.download_directory,
+                                unquote(str(match.group(1))))
+        else:
+            file = os.path.join(self.download_directory, item.id + '.zip')
 
         self.download_status[item.id]['status'] = 'downloading'
         self.download_status[item.id]['size'] = int(

--- a/camp-collective/bandcamp.py
+++ b/camp-collective/bandcamp.py
@@ -13,16 +13,16 @@ from bs4 import BeautifulSoup
 
 
 class Bandcamp:
-    FORMATS = [
-        'wav',
-        'forbis',
-        'flac',
-        'mp3-v0',
-        'mp3-320',
-        'alac',
-        'aiff-lossless',
-        'aac-hi'
-    ]
+    FORMATS = {
+        'wav': 'wav',
+        'forbis': 'ogg',
+        'flac': 'flac',
+        'mp3-v0': 'mp3',
+        'mp3-320': 'mp3',
+        'alac': 'm4a',
+        'aiff-lossless': 'aiff',
+        'aac-hi': 'm4a'
+    }
 
     session = None
     file_format = None
@@ -96,7 +96,7 @@ class Bandcamp:
     async def download_item(self, item, file_format=None):
         file_format = file_format if file_format is not None else self.file_format
 
-        if file_format not in Bandcamp.FORMATS:
+        if file_format not in Bandcamp.FORMATS.keys():
             raise RuntimeError('File format %s is not supported by bandcamp' % file_format)
 
         self.download_status[item.id] = {
@@ -152,7 +152,11 @@ class Bandcamp:
             file = os.path.join(self.download_directory,
                                 unquote(str(match.group(1))))
         else:
-            file = os.path.join(self.download_directory, item.id + '.zip')
+            if item.type == 'track':
+                file_ext = '.' + self.FORMATS[file_format]
+            else:
+                file_ext = '.zip'
+            file = os.path.join(self.download_directory, item.id + file_ext)
 
         self.download_status[item.id]['status'] = 'downloading'
         self.download_status[item.id]['size'] = int(

--- a/camp-collective/collection.py
+++ b/camp-collective/collection.py
@@ -31,3 +31,6 @@ class Item:
     type = None
     artist = None
     url = None
+
+    def as_dict(self):
+        return dict(self.__dict__)


### PR DESCRIPTION
Thanks for writing this! I also contacted support and got:
>Unfortunately there isn't a bulk download feature, although that is something we're thinking about. Your best bet is to go one-by-one through your Collection to grab the files, though we do understand that is quite the monstrous task.

I've tested a couple of scripts people have written to bulk download and this one is by far the best, it worked without a hitch following your README. That being said, after doing an initial download of my collection I looked at the status file and got thoughts of potential additional functionality if it saved more of the `Item` information. When reading through the code to learn more about how it works I found some tweaks and (hopefully) improvements I could add. The commits in this PR should hopefully be pretty self-explanatory, but for a quick summary:
* Record `Item` data + output filename and downloaded quality in status JSON file. (This does not break compatibility with old status files)
* Clean up color printing using the python `.format` function
* Join output filename using `os.path.join` and have correct extension for id named track downloads

