### PR TITLE
Login fixups & download 

### DIFF
--- a/camp-collective/__main__.py
+++ b/camp-collective/__main__.py
@@ -39,7 +39,7 @@ async def _main(data):
         if len(kv) == 1:
             kv.append(None)
 
-        return kv
+        return kv[0].strip(), kv[1]
 
     cookie_dict = dict([parse_cookie(cookie_comb)
                         for cookie_comb in cookie_string.split(';')])

--- a/camp-collective/bandcamp.py
+++ b/camp-collective/bandcamp.py
@@ -38,7 +38,7 @@ class Bandcamp:
         self.download_directory = download_directory if download_directory is not None else os.getcwd()
 
     async def load_user_data(self):
-        data = await self.get_page_data('https://bandcamp.com')
+        data = await self.get_page_data('https://bandcamp.com/settings')
 
         if data is None:
             return False

--- a/camp-collective/bandcamp.py
+++ b/camp-collective/bandcamp.py
@@ -177,16 +177,21 @@ class Bandcamp:
 
         def writeFileToFile(resp, filename):
             with open(filename, 'wb') as fd:
-                for chunk in resp.iter_content(chunk_size=128):
-                    self.download_status[item.id]['downloaded_size'] += len(
-                        chunk)
-                    fd.write(chunk)
+                try:
+                    for chunk in resp.iter_content(chunk_size=128):
+                        self.download_status[item.id]['downloaded_size'] += len(
+                            chunk)
+                        fd.write(chunk)
+                    self.download_status[item.id]['status'] = 'done'
+                except Exception as e:
+                    # e.g. urllib3.exceptions.ProtocolError: ('Connection broken: IncompleteRead(90734 bytes read, 765947000 more expected)', IncompleteRead(90734 bytes read, 765947000 more expected))
+                    self.download_status[item.id]['status'] = 'failed'
+                    self.download_status[item.id]['error'] = repr(e)
 
         loop = asyncio.get_event_loop()
         await loop.run_in_executor(None, writeFileToFile, resp, file)
-        self.download_status[item.id]['status'] = 'done'
 
-        return file
+        return None if self.download_status[item.id]['status'] == 'failed' else file
 
     async def get_page_data(self, url):
         resp = await self.session.get(url)

--- a/camp-collective/bandcamp.py
+++ b/camp-collective/bandcamp.py
@@ -178,7 +178,7 @@ class Bandcamp:
         def writeFileToFile(resp, filename):
             with open(filename, 'wb') as fd:
                 try:
-                    for chunk in resp.iter_content(chunk_size=128):
+                    for chunk in resp.iter_content(chunk_size=1024 * 1024):
                         self.download_status[item.id]['downloaded_size'] += len(
                             chunk)
                         fd.write(chunk)


### PR DESCRIPTION
Hello! I tried giving this a go to grab a bunch of albums.

The first 2 commits are necessary here to get the initial user data fetch working. I'm assuming it's something that's changed in bandcamp over the intervening years.

I'm not sure how to re-trigger the "Connection Broken", I must have got lucky. But logging the failure with everything else should make for a better experience.

Finally, increasing the chunk size seems to make things a bit more sprightly.

Thanks! This was just what I was looking for :)
